### PR TITLE
Fix README phrasing about dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,8 @@ it should work out of the box.
 ### Dark mode
 
 If you make use of the dark mode feature in macOS, you might want to configure `bat` to use a different
-theme based on the OS theme. The following snippet uses the `default` theme when in the light mode
-and the `GitHub` theme when in the dark mode.
+theme based on the OS theme. The following snippet uses the `default` theme when in the _dark mode_
+and the `GitHub` theme when in the _light mode_.
 
 ```bash
 alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"


### PR DESCRIPTION
The readme phrasing is incorrect in regard of the dark mode detection on macOs, this PR fixes that.